### PR TITLE
Fix Event factory

### DIFF
--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :event do
-    title Faker::String.random(6..20)
-    place_title Faker::String.random(1..30)
-    description Faker::String.random(30..100)
+    title Faker::Lorem.characters(10)
+    place_title Faker::Lorem.characters(20)
+    description Faker::Lorem.sentence(10)
     start_at Time.now
     end_at 1.week.from_now
   end


### PR DESCRIPTION
When the fields were filled with random values, the tests sometimes did not work.